### PR TITLE
chore(ci): bump swagger version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
       IMAGE_NAME: "swagger-codegen-cli"
       TAG: "latest"
       DOCKERFILE: "Dockerfile"
-      JAR_VERSION: "3.0.32"
+      JAR_VERSION: "3.0.41"
     name: Publish images
     runs-on: "ubuntu-latest"
     needs: setup


### PR DESCRIPTION
Hi,

thanks for providing this workaround. I'm looking for a more recent version of the CLI. I haven't tested this, but is this enough to trigger a new image release?

Thanks in advance!